### PR TITLE
Removing cliques for the data set.

### DIFF
--- a/scripts/Binomial.py
+++ b/scripts/Binomial.py
@@ -13,7 +13,7 @@ from functions import *
 
 # parameters
 turns = 200
-repetitions = 10
+repetitions = 11
 ub_tournament_size = 50
 ub_seed = 10
 num_sample_players = 10
@@ -63,9 +63,7 @@ for tournament_size in tqdm.tqdm(range(2, ub_tournament_size + 1)):
                                                                   tournament_id,
                                                                               0)
 
-                        min_itemsize = {'player_name': 100,
-                                        'neighbors': 200,
-                                        'cliques': 200}
+                        min_itemsize = {'player_name': 100, 'neighbors': 200}
 
                         hdf.append(experiment, results, format='table', data_columns=True,
                                    min_itemsize=min_itemsize)

--- a/scripts/Small_world.py
+++ b/scripts/Small_world.py
@@ -65,9 +65,7 @@ for tournament_size in tqdm.tqdm(range(2, ub_tournament_size + 1)):
                                                                   tournament_id,
                                                       initial_neighborhood_size)
 
-                        min_itemsize = {'player_name': 100,
-                                        'neighbors': 200,
-                                        'cliques': 200}
+                        min_itemsize = {'player_name': 100, 'neighbors': 200}
 
                         hdf.append(experiment, results, format='table', data_columns=True,
                                    min_itemsize=min_itemsize)

--- a/scripts/complete.py
+++ b/scripts/complete.py
@@ -45,7 +45,7 @@ for tournament_size in tqdm.tqdm(range(2, ub_tournament_size + 1)):
         results = tournament_results(G, tournament_size, num_sample_players,
                                              players, turns, edges, repetitions)
 
-        min_itemsize = {'player_name': 100, 'neighbors': 200, 'cliques': 200}
+        min_itemsize = {'player_name': 100, 'neighbors': 200}
 
         hdf.append(experiment, results, format='table', data_columns=True,
                                                       min_itemsize=min_itemsize)

--- a/scripts/functions.py
+++ b/scripts/functions.py
@@ -154,7 +154,6 @@ def tournament_results(G, seed, p, players, turns, edges,
                          [list(results.game.RPST())[3] for _ in results.players],
                          'connectivity' : nx.node_connectivity(G),
                          'clustering' : nx.average_clustering(G),
-                         'cliques' : compress_list_of_lists(cliques),
                          'initial_neighbourhood_size': [initial_neighbourhood_size for _ in results.players],
                         })
 


### PR DESCRIPTION
The parameter cliques has been removed. Reasons :
- The lenght could get very large, specially in the binomial experiement
- We can get the cliques easily, because we have the graph and players seeds

Thus if the cliques are needed in the analysis a function to calculate
them could be written.

Cliques have been removed for the function.py where they were being written
and for the item sizes in the experiments script.
